### PR TITLE
fix: Remove deprecated unload event

### DIFF
--- a/src/util/browser/event.js
+++ b/src/util/browser/event.js
@@ -42,9 +42,6 @@ var Event = {
   }
 };
 
-if (global.onunload !== undefined)
-  Event.on(global, 'unload', Event.detach, Event);
-
 module.exports = {
   Event: Event
 };


### PR DESCRIPTION
This removes the usage of the unload event which seems to not be needed anymore and is actually deprecated.

It should get rid of Deprecated warnings in Google Lighthouse and PageSpeed.

References:
- https://github.com/faye/faye/issues/547#issuecomment-2704679359
- https://developer.chrome.com/docs/web-platform/deprecating-unload